### PR TITLE
Simplify flag.Usage implementation.

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,6 @@ import (
 func usage() {
 	fmt.Fprintf(os.Stderr, "usage: embedmd [flags] [path ...]\n")
 	flag.PrintDefaults()
-	os.Exit(2)
 }
 
 func main() {


### PR DESCRIPTION
Remove unnecessary `os.Exit` call. The `flag` package is responsible for doing that.

You can look at the [default implementation](https://godoc.org/flag#pkg-variables) of `flag.Usage` and confirm it doesn't call `os.Exit(2)` either:

```Go
var Usage = func() {
	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
	PrintDefaults()
}
```

Also see https://github.com/mdempsky/unconvert/commit/3b9aa41c71a855a5f5fee96dc751979ce6e8cbbe and https://github.com/shurcooL/backlog/issues/4.

This is a really minor thing, but many people will be looking at this code, so I'm happy to help contribute improvements to style so that other people have a better example to learn/copy from (plus, I don't wanna have to keep making these PRs on even more repos 😉).