### PR TITLE
Do not skip lines right after code sections

### DIFF
--- a/embedmd/parser_test.go
+++ b/embedmd/parser_test.go
@@ -42,12 +42,24 @@ func TestParser(t *testing.T) {
 		{
 			name: "a command",
 			in:   "one\n[embedmd]:# (code.go)",
-			out:  "one\n[embedmd]:# (code.go)\nOK",
+			out:  "one\n[embedmd]:# (code.go)\nOK\n",
 			run: func(w io.Writer, cmd *command) error {
 				if cmd.path != "code.go" {
 					return fmt.Errorf("bad command")
 				}
-				fmt.Fprint(w, "OK")
+				fmt.Fprint(w, "OK\n")
+				return nil
+			},
+		},
+		{
+			name: "a command then some text",
+			in:   "one\n[embedmd]:# (code.go)\nYay\n",
+			out:  "one\n[embedmd]:# (code.go)\nOK\nYay\n",
+			run: func(w io.Writer, cmd *command) error {
+				if cmd.path != "code.go" {
+					return fmt.Errorf("bad command")
+				}
+				fmt.Fprint(w, "OK\n")
 				return nil
 			},
 		},
@@ -65,6 +77,16 @@ func TestParser(t *testing.T) {
 			name: "unbalanced code section",
 			in:   "one\n```\nsome code\n",
 			err:  "3: unbalanced code section",
+		},
+		{
+			name: "two contiguous code sections",
+			in:   "\n```go\nhello\n```\n```go\nbye\n```\n",
+			out:  "\n```go\nhello\n```\n```go\nbye\n```\n",
+		},
+		{
+			name: "two non contiguous code sections",
+			in:   "```go\nhello\n```\n\n```go\nbye\n```\n",
+			out:  "```go\nhello\n```\n\n```go\nbye\n```\n",
 		},
 	}
 


### PR DESCRIPTION
Contiguous code sections are handled incorrectly,
causing

Fixes #35

Change-Id: Ifdd728613076c05da9738b6cdad997bcd2a820fb