### PR TITLE
Indent code if embedmd command is indented

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-
-go:
-  - 1.7.x
-  - 1.8.x
-  - 1.x
-  - master
-script:
-  - go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-[![Build Status](https://travis-ci.org/campoy/embedmd.svg)](https://travis-ci.org/campoy/embedmd) [![Go Report Card](https://goreportcard.com/badge/github.com/campoy/embedmd)](https://goreportcard.com/report/github.com/campoy/embedmd)
+# Fork of embedmd
 
+This fork supports `embedmd` commands that are indented in the Markdown file,
+e.g. as part of a numbered list of steps:
+
+```
+1.   A command:
+
+     [embedmd]:# (test/hello.go /func main/ $)
+```
 
 # embedmd
 
@@ -72,18 +80,15 @@ files, since `.go` matches `go`). However, this will fail with other files like
 
 > You can install Go by following [these instructions](https://golang.org/doc/install).
 
-`embedmd` is written in Go, so if you have Go installed you can install it with
-`go get`:
+`embedmd` is written in Go, so if you have Go 1.16 or later installed,
+you can install it with `go install`:
 
 ```
-go get github.com/campoy/embedmd
+go get github.com/halvards/embedmd@latest
 ```
 
 This will download the code, compile it, and leave an `embedmd` binary
 in `$GOPATH/bin`.
-
-Eventually, and if there's enough interest, I will provide binaries for
-every OS and architecture out there ... _eventually_.
 
 ## Usage:
 

--- a/embedmd/command.go
+++ b/embedmd/command.go
@@ -22,6 +22,7 @@ import (
 type command struct {
 	path, lang string
 	start, end *string
+	leftPad    string
 }
 
 func parseCommand(s string) (*command, error) {

--- a/embedmd/embedmd.go
+++ b/embedmd/embedmd.go
@@ -56,6 +56,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 )
 
 // Process reads markdown from the given io.Reader searching for an embedmd
@@ -104,9 +105,15 @@ func (e *embedder) runCommand(w io.Writer, cmd *command) error {
 		b = append(b, '\n')
 	}
 
-	fmt.Fprintln(w, "```"+cmd.lang)
-	w.Write(b)
-	fmt.Fprintln(w, "```")
+	fmt.Fprintln(w, cmd.leftPad+"```"+cmd.lang)
+	lines := strings.Split(string(b), "\n")
+	if len(lines) > 0 {
+		lines = lines[:len(lines)-1]
+	}
+	for _, line := range lines {
+		fmt.Fprintln(w, cmd.leftPad+line)
+	}
+	fmt.Fprintln(w, cmd.leftPad+"```")
 	return nil
 }
 

--- a/embedmd/embedmd_go113_test.go
+++ b/embedmd/embedmd_go113_test.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build !go1.14
+
+package embedmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestProcessGo113(t *testing.T) {
+	tc := []struct {
+		name  string
+		in    string
+		dir   string
+		files map[string][]byte
+		urls  map[string][]byte
+		out   string
+		err   string
+		diff  bool
+	}{
+		{
+			name: "embedding code from a bad URL",
+			in: "# This is some markdown\n" +
+				"[embedmd]:# (https://fakeurl.com\\main.go)\n" +
+				"Yay!\n",
+			err: "2: could not read https://fakeurl.com\\main.go: parse https://fakeurl.com\\main.go: invalid character \"\\\\\" in host name",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			cp := mixedContentProvider{tt.files, tt.urls}
+			if tt.diff {
+				cp.files["file.md"] = []byte(tt.in)
+			}
+			opts := []Option{WithFetcher(cp)}
+			if tt.dir != "" {
+				opts = append(opts, WithBaseDir(tt.dir))
+			}
+			err := Process(&out, strings.NewReader(tt.in), opts...)
+			if !eqErr(t, tt.name, err, tt.err) {
+				return
+			}
+			if tt.out != out.String() {
+				t.Errorf("case [%s]: expected output:\n###\n%s\n###; got###\n%s\n###", tt.name, tt.out, out.String())
+			}
+		})
+	}
+}

--- a/embedmd/embedmd_go114_test.go
+++ b/embedmd/embedmd_go114_test.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build go1.14
+
+package embedmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestProcessGo114(t *testing.T) {
+	tc := []struct {
+		name  string
+		in    string
+		dir   string
+		files map[string][]byte
+		urls  map[string][]byte
+		out   string
+		err   string
+		diff  bool
+	}{
+		{
+			name: "embedding code from a bad URL",
+			in: "# This is some markdown\n" +
+				"[embedmd]:# (https://fakeurl.com\\main.go)\n" +
+				"Yay!\n",
+			err: "2: could not read https://fakeurl.com\\main.go: parse \"https://fakeurl.com\\\\main.go\": invalid character \"\\\\\" in host name",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			cp := mixedContentProvider{tt.files, tt.urls}
+			if tt.diff {
+				cp.files["file.md"] = []byte(tt.in)
+			}
+			opts := []Option{WithFetcher(cp)}
+			if tt.dir != "" {
+				opts = append(opts, WithBaseDir(tt.dir))
+			}
+			err := Process(&out, strings.NewReader(tt.in), opts...)
+			if !eqErr(t, tt.name, err, tt.err) {
+				return
+			}
+			if tt.out != out.String() {
+				t.Errorf("case [%s]: expected output:\n###\n%s\n###; got###\n%s\n###", tt.name, tt.out, out.String())
+			}
+		})
+	}
+}

--- a/embedmd/embedmd_test.go
+++ b/embedmd/embedmd_test.go
@@ -234,13 +234,6 @@ func TestProcess(t *testing.T) {
 			err: "2: could not read https://fakeurl.com/main.go: status Not Found",
 		},
 		{
-			name: "embedding code from a bad URL",
-			in: "# This is some markdown\n" +
-				"[embedmd]:# (https://fakeurl.com\\main.go)\n" +
-				"Yay!\n",
-			err: "2: could not read https://fakeurl.com\\main.go: parse https://fakeurl.com\\main.go: invalid character \"\\\\\" in host name",
-		},
-		{
 			name: "ignore commands in code blocks",
 			in: "# This is some markdown\n" +
 				"```markdown\n" +

--- a/embedmd/parser.go
+++ b/embedmd/parser.go
@@ -65,9 +65,9 @@ func parsingText(out io.Writer, s textScanner, run commandRunner) (state, error)
 		return nil, nil // end of file, which is fine.
 	}
 	switch line := s.Text(); {
-	case strings.HasPrefix(line, "[embedmd]:#"):
+	case strings.HasPrefix(strings.TrimSpace(line), "[embedmd]:#"):
 		return parsingCmd, nil
-	case strings.HasPrefix(line, "```"):
+	case strings.HasPrefix(strings.TrimSpace(line), "```"):
 		return codeParser{print: true}.parse, nil
 	default:
 		fmt.Fprintln(out, s.Text())
@@ -83,13 +83,14 @@ func parsingCmd(out io.Writer, s textScanner, run commandRunner) (state, error) 
 	if err != nil {
 		return nil, err
 	}
+	cmd.leftPad = strings.Split(line, strings.TrimSpace(line))[0]
 	if err := run(out, cmd); err != nil {
 		return nil, err
 	}
 	if !s.Scan() {
 		return nil, nil // end of file, which is fine.
 	}
-	if strings.HasPrefix(s.Text(), "```") {
+	if strings.HasPrefix(strings.TrimSpace(s.Text()), "```") {
 		return codeParser{print: false}.parse, nil
 	}
 	fmt.Fprintln(out, s.Text())
@@ -105,7 +106,7 @@ func (c codeParser) parse(out io.Writer, s textScanner, run commandRunner) (stat
 	if !s.Scan() {
 		return nil, fmt.Errorf("unbalanced code section")
 	}
-	if !strings.HasPrefix(s.Text(), "```") {
+	if !strings.HasPrefix(strings.TrimSpace(s.Text()), "```") {
 		return c.parse, nil
 	}
 

--- a/embedmd/parser_test.go
+++ b/embedmd/parser_test.go
@@ -52,6 +52,18 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
+			name: "an indented command",
+			in:   "one\n    [embedmd]:# (code.go)",
+			out:  "one\n    [embedmd]:# (code.go)\nOK\n",
+			run: func(w io.Writer, cmd *command) error {
+				if cmd.path != "code.go" {
+					return fmt.Errorf("bad command")
+				}
+				fmt.Fprint(w, "OK\n")
+				return nil
+			},
+		},
+		{
 			name: "a command then some text",
 			in:   "one\n[embedmd]:# (code.go)\nYay\n",
 			out:  "one\n[embedmd]:# (code.go)\nOK\nYay\n",
@@ -77,6 +89,11 @@ func TestParser(t *testing.T) {
 			name: "unbalanced code section",
 			in:   "one\n```\nsome code\n",
 			err:  "3: unbalanced code section",
+		},
+		{
+			name: "an indented code section",
+			in:   "\n    ```go\n    hello\n    ```\n",
+			out:  "\n    ```go\n    hello\n    ```\n",
 		},
 		{
 			name: "two contiguous code sections",

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/halvards/embedmd
 
 go 1.14
 
-require (
-	github.com/campoy/embedmd v1.0.0
-	github.com/pmezard/go-difflib v1.0.0
-)
+require github.com/pmezard/go-difflib v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
-module github.com/campoy/embedmd
+module github.com/halvards/embedmd
 
-require github.com/pmezard/go-difflib v1.0.0
+go 1.14
+
+require (
+	github.com/campoy/embedmd v1.0.0
+	github.com/pmezard/go-difflib v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
-github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
+github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/integration_test.go
+++ b/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -20,5 +21,29 @@ func TestIntegration(t *testing.T) {
 	}
 	if string(got) != string(wants) {
 		t.Fatalf("got bad result (compared to result.md):\n%s", got)
+	}
+}
+
+func TestRunTwice(t *testing.T) {
+	cmd := exec.Command("embedmd", "docs.md")
+	cmd.Dir = "sample"
+	got, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not process file (%v): %s", err, got)
+	}
+
+	cmdAgain := exec.Command("embedmd")
+	cmdAgain.Dir = "sample"
+	cmdAgain.Stdin = strings.NewReader(string(got))
+	gotAgain, err := cmdAgain.CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not process file (%v): %s", err, got)
+	}
+	wants, err := ioutil.ReadFile(filepath.Join("sample", "result.md"))
+	if err != nil {
+		t.Fatalf("could not read result: %v", err)
+	}
+	if string(gotAgain) != string(wants) {
+		t.Fatalf("got bad result (compared to result.md):\n%s", gotAgain)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@
 //     output.
 //
 // For more information on the format of the commands, read the documentation
-// of the github.com/campoy/embedmd/embedmd package.
+// of the ./embedmd package.
 package main
 
 import (
@@ -41,7 +41,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/campoy/embedmd/embedmd"
+	"github.com/halvards/embedmd/embedmd"
 	"github.com/pmezard/go-difflib/difflib"
 )
 

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,3 +1,0 @@
-# embedmd releases
-
-You can find all the previously released versions in https://github.com/campoy/embedmd/releases.

--- a/releases/release.sh
+++ b/releases/release.sh
@@ -19,7 +19,7 @@ for goos in "${GOOSS[@]}"; do
         echo "\n\nbuilding $goos $goarch"
         mkdir embedmd
         pushd embedmd
-        GOOS=$goos GOARCH=$goarch go build -ldflags "-X main.version=$TAG" github.com/campoy/embedmd
+        GOOS=$goos GOARCH=$goarch go build -ldflags "-X main.version=$TAG" github.com/halvards/embedmd
         popd
         tar -cvzf "downloads/$TAG/embedmd.$TAG.$goos.$goarch.tar.gz" embedmd
         rm -rf embedmd

--- a/sample/docs.md
+++ b/sample/docs.md
@@ -16,6 +16,10 @@ Followed by an `import` statement:
 
 [embedmd]:# (hello.go /import/ /\)/)
 
+And an indented `import` statement:
+
+    [embedmd]:# (hello.go /import/ /\)/)
+
 You can also see how to get the current time:
 
 [embedmd]:# (hello.go /time\.[^)]*\)/)

--- a/sample/docs.md
+++ b/sample/docs.md
@@ -32,4 +32,4 @@ print 'hello'
 
 And why not include some file directly from GitHub?
 
-[embedmd]:# (https://raw.githubusercontent.com/campoy/embedmd/master/sample/hello.go /func main/ $)
+[embedmd]:# (https://raw.githubusercontent.com/halvards/embedmd/main/sample/hello.go /func main/ $)

--- a/sample/result.md
+++ b/sample/result.md
@@ -46,6 +46,16 @@ import (
 )
 ```
 
+And an indented `import` statement:
+
+    [embedmd]:# (hello.go /import/ /\)/)
+    ```go
+    import (
+    	"fmt"
+    	"time"
+    )
+    ```
+
 You can also see how to get the current time:
 
 [embedmd]:# (hello.go /time\.[^)]*\)/)

--- a/sample/result.md
+++ b/sample/result.md
@@ -71,7 +71,7 @@ print 'hello'
 
 And why not include some file directly from GitHub?
 
-[embedmd]:# (https://raw.githubusercontent.com/campoy/embedmd/master/sample/hello.go /func main/ $)
+[embedmd]:# (https://raw.githubusercontent.com/halvards/embedmd/main/sample/hello.go /func main/ $)
 ```go
 func main() {
 	fmt.Println("Hello, there, it is", time.Now())


### PR DESCRIPTION
This change means that:

- indented `embedmd` commands are no longer ignored; and
- the indent (any whitespace as defined by `strings.TrimSpace`) is
  prepended to each line of code.

Added an integration test that runs `embedmd` twice. This ensures that
embedded code is not duplicated or otherwise altered on the second run.

Reason for change: I implemented this change because I had code that
was part of steps in an ordered list.