### PR TITLE
Changed go get to go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ files, since `.go` matches `go`). However, this will fail with other files like
 > You can install Go by following [these instructions](https://golang.org/doc/install).
 
 `embedmd` is written in Go, so if you have Go installed you can install it with
-`go get`:
+`go install`:
 
 ```
-go get github.com/campoy/embedmd
+go install github.com/campoy/embedmd@latest
 ```
 
 This will download the code, compile it, and leave an `embedmd` binary


### PR DESCRIPTION
Signed-off-by: avaakash <as86414@gmail.com>
This PR changes the installation command from using `go get` to `go install` with the `@latest` tag as per the new golang docs. `go get` has been deprecated from go v1.17 ([here](https://go.dev/doc/go-get-install-deprecation))