### PR TITLE
CI: travis-ci -> github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: Build and Test
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.11', '1.12', '1.13' ]
+    name: Go Version ${{ matrix.go }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go install .
+      - run: go test ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-
-go:
-  - 1.7.x
-  - 1.8.x
-  - 1.x
-  - master
-script:
-  - go test ./...

--- a/embedmd/command_test.go
+++ b/embedmd/command_test.go
@@ -112,6 +112,7 @@ func eqPtr(a, b *string) bool {
 }
 
 func eqErr(t *testing.T, id string, err error, msg string) bool {
+	t.Helper()
 	if err == nil && msg == "" {
 		return true
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/campoy/embedmd
 
+go 1.11
+
 require github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
It looks like travis is not running CI for this project anymore. This PR moves the CI to github actions.

 - use t.Helper() to not get confused with where the error happened in a test.
 - require go 1.11 (go mod is not available in earlier versions)

Note: to run test for later go version > 1.13, we would have to update an expected error in `embedmd_test.go`.